### PR TITLE
Egg Writer: Support exporting of tags

### DIFF
--- a/yabee_libs/egg_writer.py
+++ b/yabee_libs/egg_writer.py
@@ -168,7 +168,7 @@ class Group:
             lvlSpace = '  ' * level
 
             # SCALAR TAGS
-            scalar_tags = ('collide-mask', 'into-collide-mask', 'from-collide-mask', 'fps', 'bin', 'alpha', 'occluder', 'draw-order', 'scroll_u', 'scroll_v', 'decal')
+            scalar_tags = ('collide-mask', 'into-collide-mask', 'from-collide-mask', 'fps', 'bin', 'alpha', 'occluder', 'draw_order', 'scroll_u', 'scroll_v', 'decal')
             for stag in scalar_tags:
                 if stag in self.object:
                     egg_str += tag(f'<Scalar> {stag} {{ {self.object.get(stag)} }}')


### PR DESCRIPTION
The biggest feature missing from this is tags. I've added the most commonly used _(or any that for some reason i have had to use throughout the past couple of years maintaining my own local fork of the plugin)_

This is best used in conjunction with a plugin that provides a simple interface for adding and validating panda3d tags - I am working on a plugin for that separately unless you think having that feature would fit into this.

Currently supported tags:
## Scalar Tags:
_Tags that are written to the egg as `<Scalar> tag { value }`_
* collide-mask
* into-collide mask
* from-collide mask
* alpha
* bin
* scroll_u
* scroll_v
* decal
* draw_order
* occluder
* fps

## Single Value Tags
_Tags that are written to the egg as `<TagName> { value }`_
* ObjectType
* Collide
* Billboard
* Switch
* DCS

## "Special" Tags
_Tags that don't follow a repeatable pattern_
* SwitchCondition
* Instance